### PR TITLE
메일 페이지 AI 일정 추가 API 연결

### DIFF
--- a/src/entities/calendar/model.ts
+++ b/src/entities/calendar/model.ts
@@ -1,31 +1,4 @@
-import { CalendarEvent, Category } from './type';
-
-export const events: CalendarEvent[] = [
-  {
-    start: '2025-02-09T14:00:00',
-    end: '2025-02-12T14:00:00',
-    title: '놀자fsdf',
-    type: 'Schedule',
-    isRepeat: false,
-    category: 2,
-    allDay: true,
-    location: null,
-    startEditable: true,
-    durationEditable: true,
-  },
-  {
-    start: '2025-02-09T14:00:00',
-    end: '2025-02-09T14:00:00',
-    title: '공부하기',
-    type: 'Todo',
-    isRepeat: false,
-    priority: 1,
-    memo: 'adafsdfadfa',
-    location: null,
-    startEditable: true,
-    durationEditable: false,
-  },
-];
+import { Category } from './type';
 
 export const categorys: Category[] = [
   { id: 1, name: '나의 일정', color: '#3B82F6', active: true },

--- a/src/entities/calendar/type.ts
+++ b/src/entities/calendar/type.ts
@@ -15,7 +15,7 @@ export interface Category {
 export interface CalendarEvent {
   type: EventType;
   title: string;
-  memo: string;
+  memo: string | null;
   isRepeat: boolean;
   start: string;
   end: string;

--- a/src/entities/calendar/type.ts
+++ b/src/entities/calendar/type.ts
@@ -15,7 +15,7 @@ export interface Category {
 export interface CalendarEvent {
   type: EventType;
   title: string;
-  memo?: string;
+  memo: string;
   isRepeat: boolean;
   start: string;
   end: string;
@@ -29,6 +29,7 @@ export interface CalendarEvent {
 
 export interface Schedule {
   title: string;
+  memo: string | null;
   allDay: boolean;
   isRepeat: boolean;
   startDate: string;

--- a/src/features/Home/Calendar/CalendarModal/calendarModal.hook.ts
+++ b/src/features/Home/Calendar/CalendarModal/calendarModal.hook.ts
@@ -13,7 +13,7 @@ interface UseEventStateProps {
 interface EventState {
   eventType: 'Schedule' | 'Todo';
   title: string;
-  memo: string;
+  memo: string | null;
   startDate: string;
   endDate: string | null;
   selectedRepeatId: number;
@@ -127,7 +127,7 @@ const useEventState = ({ event }: UseEventStateProps) => {
       setState({
         eventType: event.type,
         title: event.title,
-        memo: event.memo,
+        memo: event.memo || null,
         startDate: event?.start || '',
         endDate: event?.end || null,
         selectedRepeatId: 1,

--- a/src/features/Home/Calendar/CalendarModal/calendarModal.hook.ts
+++ b/src/features/Home/Calendar/CalendarModal/calendarModal.hook.ts
@@ -65,6 +65,7 @@ const useEventState = ({ event }: UseEventStateProps) => {
 
   const scheduleData = {
     title: state.title,
+    memo: state.memo,
     allDay: state.isAllDay,
     isRepeat: false,
     categoryId: state.selectedCategoryId,
@@ -126,7 +127,7 @@ const useEventState = ({ event }: UseEventStateProps) => {
       setState({
         eventType: event.type,
         title: event.title,
-        memo: event.memo || '',
+        memo: event.memo,
         startDate: event?.start || '',
         endDate: event?.end || null,
         selectedRepeatId: 1,

--- a/src/features/Home/Calendar/CalendarModal/index.tsx
+++ b/src/features/Home/Calendar/CalendarModal/index.tsx
@@ -76,7 +76,7 @@ const CalendarModal = ({ onClose, event }: CalendarModalProps) => {
           <input
             className={s.calendarModalSubTitle}
             placeholder="메모"
-            value={state.memo}
+            value={state.memo || ''}
             onChange={handleChangeMemo}
           />
         </div>

--- a/src/features/Home/services/home.api.ts
+++ b/src/features/Home/services/home.api.ts
@@ -46,9 +46,10 @@ export const getScheduleList = async (params: GetScheduleListReq) => {
   );
 
   return data.map(
-    ({ title, allDay, isRepeat, startDate, endDate, category }) => ({
+    ({ title, memo, allDay, isRepeat, startDate, endDate, category }) => ({
       type: EVENT_TYPE.Schedule,
       title,
+      memo,
       allDay,
       isRepeat,
       start: startDate,

--- a/src/features/Mail/CreateScheduleModal/index.tsx
+++ b/src/features/Mail/CreateScheduleModal/index.tsx
@@ -70,6 +70,7 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
 
   const scheduleData = {
     title: state.title,
+    memo: state.memo,
     allDay: state.isAllDay,
     isRepeat: false,
     categoryId: state.selectedCategoryId,

--- a/src/features/Mail/CreateScheduleModal/index.tsx
+++ b/src/features/Mail/CreateScheduleModal/index.tsx
@@ -6,12 +6,12 @@ import useEventState from 'features/Home/Calendar/CalendarModal/calendarModal.ho
 import EventDropdown from 'features/Home/Calendar/Dropdown';
 import { useCallback, useEffect, useState } from 'react';
 import LoadingStatus from 'features/Mail/CreateScheduleModal/LoadingStatus';
-import { categorys } from 'entities/calendar/model';
 import { useAtom } from 'jotai';
 import { selectedMailIdAtom } from 'features/Mail/contexts/mail';
 import { useQuery } from '@tanstack/react-query';
 import { mailQuery } from 'features/Mail/services/mail.query';
 import { usePostScheduleMutation } from 'features/Home/services/home.mutation';
+import { useCategories } from 'entities/calendar/hooks/useCategory';
 
 const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
   const [gmailId] = useAtom(selectedMailIdAtom);
@@ -48,6 +48,8 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
 
   const { state, updateState } = useEventState({ event });
 
+  const categories = useCategories();
+
   const handleChangeInputs = (key: 'title' | 'content', value: string) => {
     updateState({ [key]: value });
   };
@@ -80,9 +82,7 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
 
   const createEvent = useCallback(() => {
     postScheduleMutate(scheduleData);
-    if (toggleModalClose) {
-      toggleModalClose?.('createSchedule');
-    }
+    toggleModalClose?.('createSchedule');
   }, [postScheduleMutate, scheduleData, toggleModalClose]);
 
   return (
@@ -177,7 +177,7 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
                   <EventDropdown
                     name="category"
                     id={state.selectedCategoryId}
-                    data={categorys}
+                    data={categories}
                     onChange={handleChangeCategory}
                   />
                 </div>

--- a/src/features/Mail/CreateScheduleModal/index.tsx
+++ b/src/features/Mail/CreateScheduleModal/index.tsx
@@ -4,13 +4,14 @@ import AlertMark from 'features/Mail/ui/AlertMark';
 import { CalendarEvent } from 'entities/calendar/type';
 import useEventState from 'features/Home/Calendar/CalendarModal/calendarModal.hook';
 import EventDropdown from 'features/Home/Calendar/Dropdown';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import LoadingStatus from 'features/Mail/CreateScheduleModal/LoadingStatus';
 import { categorys } from 'entities/calendar/model';
 import { useAtom } from 'jotai';
 import { selectedMailIdAtom } from 'features/Mail/contexts/mail';
 import { useQuery } from '@tanstack/react-query';
 import { mailQuery } from 'features/Mail/services/mail.query';
+import { usePostScheduleMutation } from 'features/Home/services/home.mutation';
 
 const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
   const [gmailId] = useAtom(selectedMailIdAtom);
@@ -64,6 +65,25 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
     updateState({
       isAllDay: !state.isAllDay,
     });
+
+  const scheduleData = {
+    title: state.title,
+    allDay: state.isAllDay,
+    isRepeat: false,
+    categoryId: state.selectedCategoryId,
+    startDate: state.startDate,
+    endDate: state.endDate,
+    location: state.location,
+  };
+
+  const { mutate: postScheduleMutate } = usePostScheduleMutation();
+
+  const createEvent = useCallback(() => {
+    postScheduleMutate(scheduleData);
+    if (toggleModalClose) {
+      toggleModalClose?.('createSchedule');
+    }
+  }, [postScheduleMutate, scheduleData, toggleModalClose]);
 
   return (
     <div className={s.background}>
@@ -191,7 +211,12 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
               >
                 취소
               </button>
-              <button className={s.button({ type: 'create' })}>확인</button>
+              <button
+                className={s.button({ type: 'create' })}
+                onClick={createEvent}
+              >
+                확인
+              </button>
             </div>
           </div>
         </div>

--- a/src/features/Mail/CreateScheduleModal/index.tsx
+++ b/src/features/Mail/CreateScheduleModal/index.tsx
@@ -107,7 +107,7 @@ const CreateScheduleModal = ({ toggleModalClose }: MailModalProps) => {
               <input
                 className={s.calendarModalSubTitle}
                 placeholder="메모"
-                value={state.memo}
+                value={state.memo || ''}
                 onChange={(e) => handleChangeInputs('content', e.target.value)}
               />
             </div>

--- a/src/pages/Home/ui/Calendar/index.tsx
+++ b/src/pages/Home/ui/Calendar/index.tsx
@@ -18,10 +18,7 @@ import * as s from './style.css';
 import './root.css';
 import theme from 'shared/styles/theme.css';
 import { useScheduleListQuery } from 'features/Home/services/home.query';
-import {
-  useCategories,
-  useCategoryList,
-} from 'entities/calendar/hooks/useCategory';
+import { useCategories } from 'entities/calendar/hooks/useCategory';
 
 const EventContent = memo(({ event }: { event: EventImpl }) => {
   const isSchedule = event.extendedProps.type === 'Schedule';
@@ -89,7 +86,6 @@ const Calendar = () => {
   const { navigate, dateRange } = useCalendarNavigation(calendarRef);
   const queryClient = useQueryClient();
 
-  useCategoryList();
   const categories = useCategories();
   const categoryIds = categories.map((category) => category.id);
 
@@ -128,6 +124,7 @@ const Calendar = () => {
     handleModalOpen({
       type: 'Schedule',
       title: '',
+      memo: '',
       start: date.toISOString(),
       end: date.toISOString(),
       startEditable: true,

--- a/src/widgets/NavigationBar/index.tsx
+++ b/src/widgets/NavigationBar/index.tsx
@@ -6,11 +6,13 @@ import TipsModal from 'features/Home/TipsModal';
 import { useState } from 'react';
 import { useInterval } from 'react-use';
 import useModal from 'shared/hooks/useModal';
+import { useCategoryList } from 'entities/calendar/hooks/useCategory';
 
 const NavigationBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useUser();
+  useCategoryList();
 
   const menus = [
     {


### PR DESCRIPTION
## 📌 작업 개요
이메일 페이지에서 일정 생성 기능 추가 중에 생긴 문제들을 해결하며 기능을 추가 했습니다.
<br>

## ✨ 작업 내용

- 일정의 memo 속성에 null type 추가
- 네비게이션 바에서 카테고리 전역 호출
- 이메일 페이지 일정 생성 기능 추가 

<br>

## 📸 자료 첨부

<br>

## 🚨 주의 사항
