### PR TITLE
React-Quill 줄바꿈 안되는 에러 수정

### DIFF
--- a/src/features/Mail/SendModal/index.tsx
+++ b/src/features/Mail/SendModal/index.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { MailModalProps } from 'entities/mail/types/MailModalProps';
 
 const SendModal = ({ toggleModalClose }: MailModalProps) => {
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState();
   const [uploadedFiles, setUploadedFiles] = useState<File[] | null>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/features/Mail/SendModal/style.css.ts
+++ b/src/features/Mail/SendModal/style.css.ts
@@ -91,6 +91,10 @@ export const editor = style({
   height: '100%',
 });
 
+globalStyle(`${editor} p`, {
+  display: 'block',
+});
+
 export const fileList = style({
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
## 📌 작업 개요
Email 모달에서 엔터키를 눌러도 밑으로 줄바꿈 되지 않는 문제를 해결했습니다.

<br>

## ✨ 작업 내용
- Global Style에서 p태그에 대한 display속성이 inline-block이여서 생기는 에러였습니다.


display 속성이 inline-block으로 지정된 엘리먼트는 하이브리드 모드처럼 동작합니다.
기본적으로 inline 엘리먼트처럼 전후 줄바꿈 없이 한 줄에 다른 엘리먼트들과 나란히 배치되지만, block 엘리먼트처럼 width와 height 속성 지정 및 margin과 padding 속성의 상하 간격 지정이 가능합니다. 다시 말해서, 내부적으로는 block 엘리먼트의 규칙을 따르면서 외부적으로 inline 엘리먼트의 규칙을 따르게 되기 때문에 Quill에서 p태그는 하나의 단락(문단)을 나타내는 태그이기에 br태그로 묶어도 작동되지 않았던거 였습니다.

<br>

## 📸 자료 첨부

https://github.com/user-attachments/assets/022568f8-7dd6-441b-959e-5e8b98eb32d9

<br>

## 🚨 주의 사항
hotfix 브랜치임으로 가장 먼저 마지 후 pull 작업하고 나머지 작업을 진행해야합니다.
