### PR TITLE
캘린더 페이지 사이드바 디자인 반영

### DIFF
--- a/src/entities/calendar/contexts/todoDate.ts
+++ b/src/entities/calendar/contexts/todoDate.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+import { NowDatePeriod } from 'shared/lib/date';
+
+export const todoSelectedDateAtom = atom<string>(NowDatePeriod);

--- a/src/features/Home/Sidebar/Display/style.css.ts
+++ b/src/features/Home/Sidebar/Display/style.css.ts
@@ -29,6 +29,7 @@ export const displayTitle = style({
 
 export const displayBtnLayout = recipe({
   base: {
+    cursor: 'pointer',
     display: 'flex',
     height: '24px',
     padding: '2px 2px 2px 22px',

--- a/src/features/Home/Sidebar/MiniCalendar/index.tsx
+++ b/src/features/Home/Sidebar/MiniCalendar/index.tsx
@@ -52,9 +52,19 @@ const MiniCalendar = () => {
     updateDate(newDate);
   };
 
-  const handleDateClick = (day: number) => {
+  const handleDateClick = (day: number, type: 'prev' | 'next' | 'day') => {
     const newDate = new Date(currentDate);
-    newDate.setDate(day);
+    console.log(day);
+    if (type === 'prev') {
+      newDate.setMonth(newDate.getMonth() - 1);
+      newDate.setDate(day);
+    } else if (type === 'next') {
+      newDate.setMonth(newDate.getMonth() + 1);
+      newDate.setDate(day);
+    } else if (type === 'day') {
+      newDate.setDate(day);
+    }
+
     updateDate(newDate);
   };
 
@@ -63,6 +73,7 @@ const MiniCalendar = () => {
 
     for (let i = startWeek - 1; i >= 0; i--) {
       const isSunday = (startWeek - i - 1) % 7 === 0;
+      console.log(i);
       days.push(
         <div
           key={`prev-${i}`}
@@ -73,6 +84,7 @@ const MiniCalendar = () => {
                 ? 'red'
                 : undefined,
           }}
+          onClick={() => handleDateClick(prevEndOfMonth - i, 'prev')}
         >
           {prevEndOfMonth - i}
         </div>
@@ -89,7 +101,7 @@ const MiniCalendar = () => {
           style={{
             color: isSunday && selectedDate !== i ? 'red' : undefined,
           }}
-          onClick={() => handleDateClick(i)}
+          onClick={() => handleDateClick(i, 'day')}
         >
           {i}
         </div>
@@ -104,6 +116,7 @@ const MiniCalendar = () => {
           key={`next-${i}`}
           className={s.miniCalendarDay({ isEmpty: true })}
           style={{ color: isSunday && selectedDate !== i ? 'red' : undefined }}
+          onClick={() => handleDateClick(i, 'next')}
         >
           {i}
         </div>
@@ -111,7 +124,7 @@ const MiniCalendar = () => {
     }
 
     return days;
-  }, [startWeek, daysInMonth, prevEndOfMonth, selectedDate, dateString]);
+  }, [startWeek, daysInMonth, prevEndOfMonth, selectedDate]);
 
   return (
     <div className={s.miniCalendarContainer}>

--- a/src/features/Home/Sidebar/MiniCalendar/style.css.ts
+++ b/src/features/Home/Sidebar/MiniCalendar/style.css.ts
@@ -56,6 +56,7 @@ export const miniCalendarDay = recipe({
     ...font.p1,
     fontWeight: '500',
     borderRadius: '8px',
+    cursor: 'pointer',
   },
   variants: {
     selected: {

--- a/src/features/Home/Sidebar/MiniCalendar/style.css.ts
+++ b/src/features/Home/Sidebar/MiniCalendar/style.css.ts
@@ -72,29 +72,3 @@ export const miniCalendarDay = recipe({
     isEmpty: false,
   },
 });
-
-export const miniCalendarSelectedDay = style({
-  display: 'flex',
-  width: '24px',
-  height: '24px',
-  margin: '-3px -5px -3px -5px',
-  justifyContent: 'center',
-  alignItems: 'center',
-  flexShrink: '0',
-  textAlign: 'center',
-  borderRadius: '12px',
-  color: theme.white,
-
-  backgroundColor: theme.blue[400],
-  ...font.H5,
-});
-
-export const miniCalendarEmptyDay = style({
-  width: '34px',
-  textAlign: 'center',
-  color: theme.black,
-  opacity: 0.3,
-  fontFamily: 'Pretendard',
-  ...font.p1,
-  fontWeight: '500',
-});

--- a/src/features/Home/Sidebar/Todo/index.tsx
+++ b/src/features/Home/Sidebar/Todo/index.tsx
@@ -3,16 +3,12 @@ import { Arrow } from 'shared/icons';
 import { TodoNormalIcon, TodoCheckedIcon } from 'features/Home/ui';
 import * as s from './style.css';
 import { useQueryClient } from '@tanstack/react-query';
-import {
-  ChangeDateToDash,
-  NowDatePeriod,
-  getNextDate,
-  getPrevDate,
-} from 'shared/lib/date';
+import { ChangeDateToDash, getNextDate, getPrevDate } from 'shared/lib/date';
 import { usePatchTodoMutation } from 'features/Home/services/home.mutation';
 import { useTodoListQuery } from 'features/Home/services/home.query';
 import { useAtom } from 'jotai';
 import { todoRenderingAtom } from 'entities/calendar/contexts/eventRendering';
+import { todoSelectedDateAtom } from 'entities/calendar/contexts/todoDate';
 
 interface TodoItem {
   id: number;
@@ -22,8 +18,7 @@ interface TodoItem {
 
 const Todo = () => {
   const queryClient = useQueryClient();
-  const NowDate = NowDatePeriod;
-  const [date, setDate] = useState(NowDate);
+  const [date, setDate] = useAtom(todoSelectedDateAtom);
   const [todoItems, setTodoItems] = useState<TodoItem[]>([]);
   const [todoRendering] = useAtom(todoRenderingAtom);
 

--- a/src/features/Home/ui/CategoryItemIcon.tsx
+++ b/src/features/Home/ui/CategoryItemIcon.tsx
@@ -41,7 +41,7 @@ const BtnCategoryItem = ({
         width="23"
         height="23"
         rx="3.5"
-        fill={isClicked ? theme.gray[50] : initialBgColor}
+        fill={initialBgColor}
       />
       <rect
         x="0.5"

--- a/src/shared/lib/date/index.ts
+++ b/src/shared/lib/date/index.ts
@@ -33,3 +33,7 @@ export const ChangeDateToDash = (dateStr: string): string => {
   const day = ('0' + date.getDate()).slice(-2);
   return `${year}-${month}-${day}`;
 };
+
+export const parseDateString = (dateStr: string): Date => {
+  return new Date(dateStr.replace(/\./g, '-'));
+};


### PR DESCRIPTION
## 📌 작업 개요
캘린더 페이지 사이드바의 디자인적으로 적용이 안된 요소들을 적용했습니다.
<br>

## ✨ 작업 내용

- display 표시 호버
- 미니 캘린더 호버
- 미니 캘린더 달 넘어가고 돌아올 시 호버 사라짐
- Empty 날짜 클릭 시 전 달로 넘어가는 기능 추가
- 카테고리 아이콘 비활성화 상태일 시 체크 표시만 없애기
- 할 일과 미니 캘린더 날짜 공유

<br>

## 📸 자료 첨부

<br>

## 🚨 주의 사항
