### PR TITLE
구글애널리틱스 & 설정 작업 중 꺼짐 모달 Issue #112

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="./logo.png" />
     <title>Carrier</title>
+
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-R049J6HQ46"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-R049J6HQ46');
+    </script>
   </head>
 
   <body>

--- a/src/features/Setting/LogoutModal/index.tsx
+++ b/src/features/Setting/LogoutModal/index.tsx
@@ -1,20 +1,20 @@
-import { useLogoutMutation } from 'features/auth/services/auth.mutation';
 import * as s from './style.css';
 
-interface LogoutModalProps {
+interface CheckModalProps {
   toggleCloseModal: () => void;
+  verification: () => void;
+  text: string;
 }
 
-const LogoutModal = ({ toggleCloseModal }: LogoutModalProps) => {
-  const { mutate: logoutMutate } = useLogoutMutation();
-
+const CheckModal = ({
+  toggleCloseModal,
+  verification,
+  text,
+}: CheckModalProps) => {
   return (
     <div className={s.container}>
       <div className={s.modalContent}>
-        <p className={s.explainText}>
-          지금 나가시면 변경된 사항이 저장되지 않을 수 있습니다. 그래도
-          나가시겠습니까?
-        </p>
+        <p className={s.explainText}>{text}</p>
         <div className={s.buttons}>
           <div
             className={s.button({ type: 'cancel' })}
@@ -22,10 +22,7 @@ const LogoutModal = ({ toggleCloseModal }: LogoutModalProps) => {
           >
             취소
           </div>
-          <div
-            className={s.button({ type: 'leave' })}
-            onClick={() => logoutMutate()}
-          >
+          <div className={s.button({ type: 'leave' })} onClick={verification}>
             나가기
           </div>
         </div>
@@ -34,4 +31,4 @@ const LogoutModal = ({ toggleCloseModal }: LogoutModalProps) => {
   );
 };
 
-export default LogoutModal;
+export default CheckModal;

--- a/src/features/Setting/LogoutModal/style.css.ts
+++ b/src/features/Setting/LogoutModal/style.css.ts
@@ -15,7 +15,7 @@ export const container = style({
 });
 
 export const modalContent = style({
-  padding: '36px 20px 16px',
+  paddingTop: '16px',
   display: 'flex',
   background: `${theme.white}`,
   width: '28rem',
@@ -28,11 +28,12 @@ export const explainText = style({
   ...font.p1,
   color: `${theme.gray[700]}`,
   textAlign: 'center',
-  padding: '12px',
+  padding: '20px 32px 12px 32px',
 });
 
 export const buttons = style({
   display: 'flex',
+  height: '78px',
   width: '100%',
   cursor: 'pointer',
 });
@@ -44,15 +45,27 @@ export const button = recipe({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    height: '48px',
+    height: '100%',
+    transition: 'background-color 0.2s ease',
+    padding: '12px',
   },
   variants: {
     type: {
       cancel: {
         color: `${theme.black}`,
+        borderRadius: '0 0 0 16px',
+        ':hover': {
+          backgroundColor: `${theme.gray[50]}`,
+          borderRadius: '0 0 0 16px',
+        },
       },
       leave: {
         color: `${theme.red[500]}`,
+        borderRadius: '0 0 16px 0',
+        ':hover': {
+          backgroundColor: `${theme.gray[50]}`,
+          borderRadius: '0 0 16px 0',
+        },
       },
     },
   },

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -2,17 +2,21 @@ import { useEffect, useMemo, useState } from 'react';
 import * as s from './style.css';
 import SettingIcon from 'pages/Setting/ui/SettingIcon';
 import EditContainer from 'features/Setting/EditContainer';
-import LogoutModal from 'features/Setting/LogoutModal';
+import CheckModal from 'features/Setting/LogoutModal';
 import useUser from 'features/user/hooks/useUser';
 import {
   useUpdateUserInfo,
   useUpdateUserPictrue,
 } from 'features/user/services/user.mutation';
 import { useAlarmTimeMutation } from 'features/AlaramTime/services/time.mutation';
+import { useNavigate } from 'react-router-dom';
+import { useLogoutMutation } from 'features/auth/services/auth.mutation';
 
 const Setting = () => {
-  const [isOpenedModal, setIsOpenedModal] = useState(false);
-  const toggleModal = () => setIsOpenedModal(true);
+  const [isOpenedModal, setIsOpenedModal] = useState<
+    'Logout' | 'Warning' | false
+  >(false);
+  const toggleModal = () => setIsOpenedModal('Logout');
 
   const { user } = useUser();
   const { mutate: updateUserInfoMutate } = useUpdateUserInfo();
@@ -86,6 +90,44 @@ const Setting = () => {
     }
   };
 
+  const navigate = useNavigate();
+  const { mutate: logoutMutate } = useLogoutMutation();
+
+  // 브라우저 닫을 때 경고창
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isButtonDisabled) {
+        event.preventDefault();
+        event.returnValue = ''; // Chrome
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isButtonDisabled]);
+
+  // 브라우저 뒤로가기 경고창
+  useEffect(() => {
+    const handleBlockNavigation = (event: Event) => {
+      if (!isButtonDisabled) {
+        event.preventDefault();
+        setIsOpenedModal('Warning');
+        navigate(1);
+        return;
+      }
+      navigate(-1);
+    };
+
+    window.addEventListener('popstate', handleBlockNavigation);
+
+    return () => {
+      window.removeEventListener('popstate', handleBlockNavigation);
+    };
+  }, [isButtonDisabled, navigate]);
+
   return (
     <main className={s.container}>
       <header className={s.header}>
@@ -138,10 +180,25 @@ const Setting = () => {
         />
       </div>
       {isOpenedModal && (
-        <LogoutModal
+        <CheckModal
           toggleCloseModal={() => {
             setIsOpenedModal(false);
           }}
+          verification={() => {
+            isOpenedModal === 'Logout'
+              ? logoutMutate()
+              : isOpenedModal === 'Warning'
+                ? navigate(-1)
+                : '';
+            setIsOpenedModal(false);
+          }}
+          text={
+            isOpenedModal === 'Logout'
+              ? '정말 로그아웃하시겠습니까?'
+              : isOpenedModal === 'Warning'
+                ? '저장하지 않은 변경 사항이 있습니다. 페이지를 떠나시겠습니까?'
+                : '계정을 삭제하시면 모든 데이터가 삭제됩니다. 그래도 삭제하시겠습니까?'
+          }
         />
       )}
     </main>


### PR DESCRIPTION
## 📌 작업 개요
구글 애널리틱스에 등록해두어서 사용자 흐름을 파악 할 수 있습니다. 
설정페이지에서 설정을 진행도중에 사용자의 실수로 창이 꺼질때 모달을 띄워서 처리해두었습니다.

<br>

## ✨ 작업 내용
- 구글 애널리틱스코드를 html header에 추가했습니다.
- 기본으로 작업되어있던 모달을 재사용가능하게 만들고 로그아웃, 꺼질때 모달을 처리해두었습니다. 
- +@ 회원탈퇴 할때도 사용할 수 있도록 처리해두었습니다.

<br>

## 📸 자료 첨부

https://github.com/user-attachments/assets/57d426d1-e510-4cd9-8994-147233a4cf86


<br>

## 🚨 주의 사항
index.html을 수정하게 되어 빠르게 마지후 pull 작업을 진행해야합니다. 또한 main에 빠른 마지를 통해서 애널리틱스 등록여부를 확인해보아야합니다.
