### PR TITLE
캘린더 페이지 화면에 보이는 날짜 범위로 요청

### DIFF
--- a/src/pages/Home/ui/Calendar/index.tsx
+++ b/src/pages/Home/ui/Calendar/index.tsx
@@ -66,9 +66,14 @@ const useCalendarNavigation = (calendarRef: React.RefObject<FullCalendar>) => {
   }, [calendarRef]);
 
   const updateDateRange = (api: CalendarApi) => {
+    const view = api.view;
+    const visibleStart = new Date(
+      view.activeStart.getTime() + 1000 * 60 * 60 * 24
+    );
+    const visibleEnd = view.activeEnd;
     setDateRange({
-      startDate: api.view.activeStart.toISOString().split('T')[0] + 'T00:00:00',
-      endDate: api.view.activeEnd.toISOString().split('T')[0] + 'T00:00:00',
+      startDate: visibleStart.toISOString().split('T')[0] + 'T00:00:00',
+      endDate: visibleEnd.toISOString().split('T')[0] + 'T23:59:59',
     });
   };
 

--- a/src/pages/Home/ui/Calendar/index.tsx
+++ b/src/pages/Home/ui/Calendar/index.tsx
@@ -67,9 +67,8 @@ const useCalendarNavigation = (calendarRef: React.RefObject<FullCalendar>) => {
 
   const updateDateRange = (api: CalendarApi) => {
     setDateRange({
-      startDate:
-        api.view.currentStart.toISOString().split('T')[0] + 'T00:00:00',
-      endDate: api.view.currentEnd.toISOString().split('T')[0] + 'T00:00:00',
+      startDate: api.view.activeStart.toISOString().split('T')[0] + 'T00:00:00',
+      endDate: api.view.activeEnd.toISOString().split('T')[0] + 'T00:00:00',
     });
   };
 


### PR DESCRIPTION
## 📌 작업 개요
본래 캘린더 페이지는 3월 달이라면 2월 말에서 부터 4월 초까지 보이고 있지만, 실제로 API 요청은 3월 1일 부터 3월 31일로 요청하고 있습니다.
 이를 화면에 보이는 날짜를 반영하게 변경했습니다.
<br>

## ✨ 작업 내용

- view 보이는대로 dateRange 변경
- start가 하루 전을 가지기 때문에 하루 보정

<br>

## 📸 자료 첨부
![image](https://github.com/user-attachments/assets/62dbfa71-b9d2-4386-a8c2-e71b4a904a39)

![image](https://github.com/user-attachments/assets/ca18359a-960b-4baa-85c4-69768b26fc1f)


<br>

## 🚨 주의 사항
