### PR TITLE
카테고리 생성 시 바로 모달에 반영

### DIFF
--- a/src/features/Home/Sidebar/Category/index.tsx
+++ b/src/features/Home/Sidebar/Category/index.tsx
@@ -39,11 +39,14 @@ const Category = () => {
         {
           id: categoryData.length + 1,
           name: newCategory,
-          color: CategoryColor[categoryData.length],
+          color: CategoryColor[categoryData.length % CategoryColor.length],
           active: true,
         },
       ]);
-      mutate({ name: newCategory, color: CategoryColor[categoryData.length] });
+      mutate({
+        name: newCategory,
+        color: CategoryColor[categoryData.length % CategoryColor.length],
+      });
       setNewCategory('카테고리');
       setIsOpenModal(false);
     }

--- a/src/features/Home/services/home.mutation.ts
+++ b/src/features/Home/services/home.mutation.ts
@@ -71,8 +71,15 @@ export const usePatchCategoryMutation = () => {
 };
 
 export const useCreateCategoryMutation = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: postCategory,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [homeKeys.CATEGORY_LIST],
+      });
+    },
   });
 };
 


### PR DESCRIPTION
## 📌 작업 개요
카테고리 생성 시 바로 모달에 반영 안되는 에러를 해결하였습니다.
또한, 카테고리 length가 color 데이터의 length를 넘어가서 카테고리를 생성 할 수 없는 상황도 해결하였습니다.

<br>

## ✨ 작업 내용

- 카테고리 생성 시 곧바로 반영
- 배열 길이 초과 시 색상 순환 처리 추가

<br>

## 📸 자료 첨부

<br>

## 🚨 주의 사항
