### PR TITLE
캘린더 border 두줄 현상

### DIFF
--- a/src/pages/Home/ui/Calendar/style.css.ts
+++ b/src/pages/Home/ui/Calendar/style.css.ts
@@ -266,3 +266,14 @@ globalStyle(
     color: theme.white,
   }
 );
+
+globalStyle('.fc-scrollgrid-section.fc-scrollgrid-section-header > th', {
+  border: 'none',
+});
+
+globalStyle(
+  '.fc-scrollgrid-section.fc-scrollgrid-section-body.fc-scrollgrid-section-liquid > td',
+  {
+    border: 'none',
+  }
+);

--- a/src/pages/Home/ui/Calendar/style.css.ts
+++ b/src/pages/Home/ui/Calendar/style.css.ts
@@ -267,12 +267,15 @@ globalStyle(
   }
 );
 
-globalStyle('.fc-scrollgrid-section.fc-scrollgrid-section-header > th', {
-  border: 'none',
-});
+globalStyle(
+  `${calendarContainer} .fc-scrollgrid-section.fc-scrollgrid-section-header > th`,
+  {
+    border: 'none',
+  }
+);
 
 globalStyle(
-  '.fc-scrollgrid-section.fc-scrollgrid-section-body.fc-scrollgrid-section-liquid > td',
+  `${calendarContainer} .fc-scrollgrid-section.fc-scrollgrid-section-body.fc-scrollgrid-section-liquid > td`,
   {
     border: 'none',
   }


### PR DESCRIPTION
## 📌 작업 개요
풀캘린더와 스타일 겹침 문제로 캘린더에 border가 두개가 생기는 현상이 발생했었는데,
특정 클래스 밑의 border는 지우는 것으로 해결했습니다.
<br>

## ✨ 작업 내용

- 특정 클래스 밑의 th와 td는 border: none;

<br>

## 📸 자료 첨부
![image](https://github.com/user-attachments/assets/c9e565ba-b6b7-4370-9373-6a3f4e1f38cf)

<br>

## 🚨 주의 사항
