### PR TITLE
할 일(투두) 상세 내용 적용

### DIFF
--- a/src/entities/calendar/model.ts
+++ b/src/entities/calendar/model.ts
@@ -12,3 +12,9 @@ export const CATEGORY_COLORS_VALUE = {
   BROWN: '#B26C1B',
   ROSE: '#D63881',
 };
+
+export const PRIORITY_VALUE: Record<string, number> = {
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+};

--- a/src/entities/calendar/type.ts
+++ b/src/entities/calendar/type.ts
@@ -54,6 +54,7 @@ export interface Todo {
   title: string;
   id: number;
   memo: string | null;
+  priority: string;
   isDone: boolean;
   date: string;
 }

--- a/src/entities/calendar/type.ts
+++ b/src/entities/calendar/type.ts
@@ -54,6 +54,7 @@ export interface Todo {
   title: string;
   id: number;
   memo: string | null;
+  location: string | null;
   priority: string;
   isDone: boolean;
   date: string;

--- a/src/features/Home/services/home.api.ts
+++ b/src/features/Home/services/home.api.ts
@@ -10,17 +10,19 @@ import {
 } from 'entities/calendar/remote';
 import { Schedule, EVENT_TYPE, Todo } from 'entities/calendar/type';
 import { toQueryString } from 'shared/lib/queryString';
+import { PRIORITY_VALUE } from 'entities/calendar/model';
 
 export const getTodoList = async (params: GetTodoListReq) => {
   const { data } = await customAxios.get<Todo[]>(
     `/todos?${toQueryString(params)}`
   );
 
-  return data.map(({ id, title, memo, isDone, date }) => ({
+  return data.map(({ id, title, memo, isDone, date, priority }) => ({
     type: EVENT_TYPE.Todo,
     eventId: id,
     title,
     memo,
+    priority: PRIORITY_VALUE[priority],
     isRepeat: false,
     start: `${date}T00:00:00`,
     end: `${date}T23:59:59`,

--- a/src/features/Home/services/home.api.ts
+++ b/src/features/Home/services/home.api.ts
@@ -18,12 +18,13 @@ export const getTodoList = async (params: GetTodoListReq) => {
     `/todos?${toQueryString(params)}`
   );
 
-  return data.map(({ id, title, memo, isDone, date, priority }) => ({
+  return data.map(({ id, title, memo, isDone, date, priority, location }) => ({
     type: EVENT_TYPE.Todo,
     eventId: id,
     title,
     memo,
     priority: PRIORITY_VALUE[priority],
+    location,
     isRepeat: false,
     start: `${date}T00:00:00`,
     end: `${date}T23:59:59`,


### PR DESCRIPTION
## 📌 작업 개요
백엔드에서 할 일의 상세 내용을 보내주지 않다가 상세 내용을 보내주게 되었기 때문에 할 일의 기능을 점진적으로 확인 했습니다. 
<br>

## ✨ 작업 내용

- Record를 이용한 우선순위 백엔드 enum을 프론트 형식으로 변환하는 객체 추가 
- priority 속성 추가
- location 속성 추가

<br>

## 📸 자료 첨부

<br>

## 🚨 주의 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 할 일(Todo) 항목에 우선순위와 위치 정보를 추가하였습니다.

- **기능 개선**
  - 할 일 목록 조회 시 각 항목의 우선순위와 위치 정보가 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->