### PR TITLE
모달 상태 스토리지 저장 안되는 현상 수정

### DIFF
--- a/src/features/auth/services/auth.mutation.ts
+++ b/src/features/auth/services/auth.mutation.ts
@@ -30,7 +30,8 @@ export const useLogoutMutation = () => {
       window.location.reload();
     },
     onSettled: () => {
-      Storage.clear();
+      Storage.delItem(TOKEN.ACCESS);
+      Storage.delItem(TOKEN.REFRESH);
     },
   });
 };

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -14,6 +14,7 @@ import Download from 'pages/Login/ui/Download';
 import { getDownloadUrl } from 'pages/Login/utils/getDownloadUrl';
 import Modal from './components/Modal';
 import { useEffect, useState } from 'react';
+import { TOKEN } from 'shared/constants';
 
 const Login = () => {
   const [unverifiedState, setUnverifiedState] = useState(false);
@@ -21,7 +22,8 @@ const Login = () => {
 
   const handleLogin = async () => {
     try {
-      Storage.clear();
+      Storage.delItem(TOKEN.ACCESS);
+      Storage.delItem(TOKEN.REFRESH);
 
       const isInApp = isElectron();
       const redirect = isInApp


### PR DESCRIPTION
## 📌 작업 개요
모달 상태 스토리지 저장 안되는 현상 수정
.clear()를 해버려서 로컬스토리지에 있던 값들이 다 사라지던 걸 수정함.

## ✨ 작업 내용


<br>

## 📸 자료 첨부

<br>

## 🚨 주의 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그아웃 및 로그인 시 전체 저장소를 비우는 대신, 접근 및 갱신 토큰만 선택적으로 삭제하도록 개선되었습니다.  
  - 이로 인해 다른 저장 데이터는 유지되며, 불필요한 데이터 손실이 방지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->