### PR TITLE
이벤트 드래그&드랍, 리사이즈시에 의도한 날짜보다 하루 더 가는 에러 Hotfix/#182

### DIFF
--- a/src/features/Home/services/home.api.ts
+++ b/src/features/Home/services/home.api.ts
@@ -11,7 +11,7 @@ import {
 } from 'entities/calendar/remote';
 import { Schedule, EVENT_TYPE, Todo } from 'entities/calendar/type';
 import { toQueryString } from 'shared/lib/queryString';
-import { getNextDateISO } from 'shared/lib/date';
+import { getadjustDateISO } from 'shared/lib/date';
 import { PRIORITY_VALUE } from 'entities/calendar/model';
 
 export const getTodoList = async (params: GetTodoListReq) => {
@@ -107,7 +107,7 @@ export const getScheduleList = async (params: GetScheduleListReq) => {
       location,
 
       start: startDate,
-      end: getNextDateISO(endDate || startDate),
+      end: getadjustDateISO(endDate || startDate, 1),
       allDay: true,
       startEditable: true,
       durationEditable: true,

--- a/src/features/Home/services/home.api.ts
+++ b/src/features/Home/services/home.api.ts
@@ -29,6 +29,9 @@ export const getTodoList = async (params: GetTodoListReq) => {
     isRepeat: false,
     start: `${date}T00:00:00`,
     end: `${date}T23:59:59`,
+
+    startDate: `${date}T00:00:00`,
+    endDate: `${date}T23:59:59`,
     isDone: isDone,
     startEditable: true,
     durationEditable: false,

--- a/src/pages/Home/ui/Calendar/index.tsx
+++ b/src/pages/Home/ui/Calendar/index.tsx
@@ -33,7 +33,7 @@ import {
   usePatchScheduleMutation,
   usePatchTodoMutation,
 } from 'features/Home/services/home.mutation';
-import { toISOStringKST } from 'shared/lib/date';
+import { getadjustDateISO, toISOStringKST } from 'shared/lib/date';
 import { PRIORITY } from 'entities/calendar/model';
 
 const EventContent = memo(({ event }: { event: EventImpl }) => {
@@ -244,9 +244,9 @@ const Calendar = () => {
         isRepeat: props.isRepeat,
         memo: props.memo ?? null,
         startDate: `${info.event.startStr}T00:00:00`,
-        endDate: info.event.endStr
-          ? `${info.event.endStr}T23:30:00`
-          : `${info.event.startStr}T23:30:00`,
+        endDate:
+          getadjustDateISO(`${info.event.endStr}T23:30:00`, -1) ||
+          `${info.event.startStr}T23:30:00`,
         categoryId: props.category!,
         location: props.location ?? null,
       };

--- a/src/shared/lib/date/index.ts
+++ b/src/shared/lib/date/index.ts
@@ -60,7 +60,7 @@ export const toISOStringKST = (date: Date): string => {
   return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 };
 
-export const getNextDateISO = (dateStr: string, days: number = 1): string => {
+export const getadjustDateISO = (dateStr: string, days: number = 1): string => {
   const date = new Date(dateStr);
   const nextDate = addDays(date, days);
 


### PR DESCRIPTION
## 📌 작업 개요
이벤트 드래그&드랍, 리사이즈시에 의도한 날짜보다 하루 더 가는 에러를 임시로 해결했습니다.
추가로 풀캘린더 더보기 이벤트에서 할 일(todo)를 수정할 시에 날짜가 무조건 오늘 날짜로 바뀌는 에러를 해결하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 일정 종료일 계산 방식이 개선되어, 일정 등록 및 수정 시 종료일이 보다 정확하게 반영됩니다.

- **리팩터**
  - 날짜 계산 유틸리티 함수의 명칭이 변경되어 코드 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->